### PR TITLE
1. Fixed bug in organs/<uberon_id> route: ressponse URL replaces blan…

### DIFF
--- a/app/routes/organ/organ.py
+++ b/app/routes/organ/organ.py
@@ -44,7 +44,7 @@ def get_organ(uberon_id):
                 term = organ.get('term')
             else:
                 term = category.get('term')
-            term = term.lower().replace(' ', '_')
+            term = term.lower().replace(' ', '-')
 
             cfg = AppConfig()
             organ_url = f"{cfg.getfield(key='DATA_PORTAL_BASE_URL')}/organs"

--- a/app/static/external-list-modal.js
+++ b/app/static/external-list-modal.js
@@ -368,7 +368,6 @@ function setupExternalModalSearch(type) {
                 } else {
                     items = config.parseApiResult(data);
                 }
-                console.log(items);
                 resultsDiv.innerHTML = '';
                 if (!items || items.length === 0) {
                     resultsDiv.innerHTML = '<div class="text-muted">No results found.</div>';


### PR DESCRIPTION
…ks in response with dash instead of underscore--e.g., "lymph node" => "lymph-node" instead of "lymph_node" 2. Removed debug console.log statement in external-list-modal.js